### PR TITLE
Add navigation carets to writing page

### DIFF
--- a/pages/writing/[slug].js
+++ b/pages/writing/[slug].js
@@ -41,6 +41,12 @@ export default function Post({ post }) {
         </nav>
       </header>
 
+      <div className={styles.backToAlbums}>
+        <Link href="/writing">
+          &lt;&lt;&lt;
+        </Link>
+      </div>
+
       <main className={writingStyles.postContainer}>
         <article className={writingStyles.post}>
           <header className={writingStyles.postHeader}>
@@ -53,12 +59,6 @@ export default function Post({ post }) {
             dangerouslySetInnerHTML={{ __html: post.contentHtml }}
           />
         </article>
-
-        <div className={writingStyles.postFooter}>
-          <Link href="/writing" className={writingStyles.backLink}>
-            ← Back to writing
-          </Link>
-        </div>
       </main>
     </div>
   );


### PR DESCRIPTION
```git-revs
e3bdadd  (Base revision)
e98dd90  Add back navigation carets to writing post page
HEAD     Remove the "Back to writing" button from the bottom of the post
```

codemcp-id: 6-docs-initialize-codemcp-for-personal-site